### PR TITLE
Test on net8, drop tests on earlier platforms

### DIFF
--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -20,12 +20,10 @@ jobs:
           - macOS-latest
           - windows-latest
         dotnet:
-          - { sdk: 3.1.x, framework: netcoreapp3.1 }
-          - { sdk: 6.0.x, framework: net6.0 }
-          - { sdk: 7.0.x, framework: net7.0 }
+          - { sdk: 8.0.x, framework: net8.0 }
         include:
           - os: windows-latest
-            dotnet: { sdk: 7.0.x, framework: net481 }
+            dotnet: { sdk: 8.0.x, framework: net481 }
 
     runs-on: ${{matrix.os}}
 

--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -21,9 +21,6 @@ jobs:
           - windows-latest
         dotnet:
           - { sdk: 8.0.x, framework: net8.0 }
-        include:
-          - os: windows-latest
-            dotnet: { sdk: 8.0.x, framework: net481 }
 
     runs-on: ${{matrix.os}}
 

--- a/TeqCrate.Test/TeqCrate.Test.fsproj
+++ b/TeqCrate.Test/TeqCrate.Test.fsproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net481;net8.0</TargetFrameworks>
     <WarningLevel>5</WarningLevel>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <WarningsAsErrors />


### PR DESCRIPTION
All earlier platforms are out of support from Microsoft, and indeed appear not to work at all.